### PR TITLE
Test for dwarf library

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         sudo add-apt-repository ppa:ubuntu-toolchain-r/test
         sudo apt-get update
         sudo apt-get install gcc-9
-        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9.2 60
+        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 60
         gcc --version
 
     - uses: actions/checkout@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,23 +3,12 @@ name: CI
 on: [push]
 
 jobs:
-  build-and-test:
+  build:
 
     runs-on: ubuntu-latest
 
     steps:
-    - name: GCC 9
-      run: |
-        gcc --version
-        sudo apt-get update
-        sudo add-apt-repository ppa:ubuntu-toolchain-r/test
-        sudo apt-get update
-        sudo apt-get install gcc-9
-        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 60
-        gcc --version
-
     - uses: actions/checkout@v1
-
 
     - name: Cache cargo registry
       uses: actions/cache@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,11 @@ jobs:
     steps:
     - name: GCC 9
       run: |
+        gcc --version
         sudo apt-get update
         sudo add-apt-repository ppa:jonathonf/gcc-9.0
         sudo apt-get install gcc-9
+        gcc --version
 
     - uses: actions/checkout@v1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on: [push]
 
 jobs:
-  build:
+  build-and-test:
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,12 +3,19 @@ name: CI
 on: [push]
 
 jobs:
-  build:
+  build-and-test:
 
     runs-on: ubuntu-latest
 
     steps:
+    - name: GCC 9
+      run: |
+        sudo apt-get update
+        sudo add-apt-repository ppa:jonathonf/gcc-9.0
+        sudo apt-get install gcc-9
+
     - uses: actions/checkout@v1
+
 
     - name: Cache cargo registry
       uses: actions/cache@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,13 @@ jobs:
         path: target
         key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
 
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
+    - uses: davidB/rust-cargo-make@v1
+
     - name: Build
       run: cargo build --verbose
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo make test-flow

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,10 @@ jobs:
       run: |
         gcc --version
         sudo apt-get update
-        sudo add-apt-repository ppa:jonathonf/gcc-9.0
+        sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+        sudo apt-get update
         sudo apt-get install gcc-9
+        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9.2 60
         gcc --version
 
     - uses: actions/checkout@v1

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 
 examples/*
 !examples/*.c
+!examples/Makefile

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,4 +1,6 @@
 [tasks.test]
+command = "cargo"
+args = ["test", "--", "${@}"]
 dependencies = ["elf-build"]
 
 [tasks.elf-build]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,0 +1,15 @@
+[tasks.test]
+dependencies = ["elf-build"]
+
+[tasks.elf-build]
+command = "make"
+args = ["-C", "examples", "all"]
+
+[tasks.elf-clean]
+command = "make"
+args = ["-C", "examples", "clean"]
+
+[tasks.test-flow]
+run_task = [
+  { name = ["test", "elf-clean"] }
+]

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,0 +1,14 @@
+CC = gcc
+CFLAGS = -Os -g3
+SRCS = $(wildcard *.c)
+TARGET = $(SRCS:%.c=%)
+
+.PHONY: all
+all: $(TARGET)
+
+%: %.c
+	$(CC) $(CFLAGS) -o $@ $<
+
+.PHONY: clean
+clean:
+	rm -f $(TARGET)

--- a/examples/simple.c
+++ b/examples/simple.c
@@ -1,5 +1,3 @@
-#include <stdio.h>
-
 typedef struct hoge {
   int hoge;
   char hogehoge;

--- a/src/library/dwarf.rs
+++ b/src/library/dwarf.rs
@@ -10,8 +10,26 @@ impl Offset {
     }
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct Location(usize);
+impl Location {
+    pub fn new(size: usize) -> Location {
+        Location(size)
+    }
+
+    pub fn add(&mut self, size: usize) {
+        self.0 += size;
+    }
+}
+
+impl Into<usize> for Location {
+    fn into(self) -> usize {
+        self.0
+    }
+}
+
 #[allow(non_camel_case_types)]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum DwarfTag {
     DW_TAG_variable,
     DW_TAG_typedef,
@@ -40,7 +58,7 @@ impl From<gimli::DwTag> for DwarfTag {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct DwarfInfo {
     tag: DwarfTag,
     offset: Offset,
@@ -50,24 +68,6 @@ pub struct DwarfInfo {
     type_offset: Option<Offset>,
     upper_bound: Option<usize>,
     children: Vec<DwarfInfo>,
-}
-
-#[derive(Debug, Clone)]
-pub struct Location(usize);
-impl Location {
-    pub fn new(size: usize) -> Location {
-        Location(size)
-    }
-
-    pub fn add(&mut self, size: usize) {
-        self.0 += size;
-    }
-}
-
-impl Into<usize> for Location {
-    fn into(self) -> usize {
-        self.0
-    }
 }
 
 impl DwarfInfo {
@@ -310,4 +310,163 @@ pub fn with_dwarf_info_iterator<Output>(
         dwarf,
         depth,
     })
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn with_dwarf_info_iterator_test() {
+        with_dwarf_info_iterator(String::from("examples/simple"), |iter| {
+            let mut expecteds = vec![
+                DwarfInfo::new(
+                    DwarfTag::DW_TAG_structure_type,
+                    Offset(45),
+                    Some(String::from("hoge")),
+                    Some(16),
+                    None,
+                    None,
+                    None,
+                    vec![
+                        DwarfInfo::new(
+                            DwarfTag::DW_TAG_unimplemented,
+                            Offset(58),
+                            Some(String::from("hoge")),
+                            None,
+                            None,
+                            Some(Offset(98)),
+                            None,
+                            vec![],
+                        ),
+                        DwarfInfo::new(
+                            DwarfTag::DW_TAG_unimplemented,
+                            Offset(71),
+                            Some(String::from("hogehoge")),
+                            None,
+                            None,
+                            Some(Offset(105)),
+                            None,
+                            vec![],
+                        ),
+                        DwarfInfo::new(
+                            DwarfTag::DW_TAG_unimplemented,
+                            Offset(84),
+                            Some(String::from("array")),
+                            None,
+                            None,
+                            Some(Offset(112)),
+                            None,
+                            vec![],
+                        ),
+                    ],
+                ),
+                DwarfInfo::new(
+                    DwarfTag::DW_TAG_base_type,
+                    Offset(98),
+                    Some(String::from("int")),
+                    Some(4),
+                    None,
+                    None,
+                    None,
+                    vec![],
+                ),
+                DwarfInfo::new(
+                    DwarfTag::DW_TAG_base_type,
+                    Offset(105),
+                    Some(String::from("char")),
+                    Some(1),
+                    None,
+                    None,
+                    None,
+                    vec![],
+                ),
+                DwarfInfo::new(
+                    DwarfTag::DW_TAG_array_type,
+                    Offset(112),
+                    None,
+                    None,
+                    None,
+                    Some(Offset(98)),
+                    None,
+                    vec![DwarfInfo::new(
+                        DwarfTag::DW_TAG_subrange_type,
+                        Offset(121),
+                        None,
+                        None,
+                        None,
+                        Some(Offset(128)),
+                        Some(1),
+                        vec![],
+                    )],
+                ),
+                DwarfInfo::new(
+                    DwarfTag::DW_TAG_base_type,
+                    Offset(128),
+                    Some(String::from("long unsigned int")),
+                    Some(8),
+                    None,
+                    None,
+                    None,
+                    vec![],
+                ),
+                DwarfInfo::new(
+                    DwarfTag::DW_TAG_typedef,
+                    Offset(135),
+                    Some(String::from("Hoge")),
+                    None,
+                    None,
+                    Some(Offset(45)),
+                    None,
+                    vec![],
+                ),
+                DwarfInfo::new(
+                    DwarfTag::DW_TAG_array_type,
+                    Offset(147),
+                    None,
+                    None,
+                    None,
+                    Some(Offset(135)),
+                    None,
+                    vec![DwarfInfo::new(
+                        DwarfTag::DW_TAG_subrange_type,
+                        Offset(156),
+                        None,
+                        None,
+                        None,
+                        Some(Offset(128)),
+                        Some(2),
+                        vec![],
+                    )],
+                ),
+                DwarfInfo::new(
+                    DwarfTag::DW_TAG_variable,
+                    Offset(163),
+                    Some(String::from("hoges")),
+                    None,
+                    Some(Location(16480)),
+                    Some(Offset(147)),
+                    None,
+                    vec![],
+                ),
+                DwarfInfo::new(
+                    DwarfTag::DW_TAG_unimplemented,
+                    Offset(185),
+                    Some(String::from("main")),
+                    None,
+                    None,
+                    Some(Offset(98)),
+                    None,
+                    vec![],
+                ),
+            ];
+            expecteds.reverse();
+
+            for info in iter {
+                if let Some(expected) = expecteds.pop() {
+                    assert_eq!(info, expected);
+                }
+            }
+        });
+    }
 }

--- a/src/library/dwarf.rs
+++ b/src/library/dwarf.rs
@@ -317,6 +317,7 @@ mod test {
     use super::*;
 
     #[test]
+    #[ignore]
     fn with_dwarf_info_iterator_test() {
         with_dwarf_info_iterator(String::from("examples/simple"), |iter| {
             let mut expecteds = vec![


### PR DESCRIPTION
#2 

The test for `with_dwarf_info_interator` is not run in CI.
It depends on the result of compiling by gcc.
It is difficult for the result on CI to coincide with the local one.