### PR TITLE
Support enum

### DIFF
--- a/examples/anonymous-enum.c
+++ b/examples/anonymous-enum.c
@@ -1,0 +1,8 @@
+enum {
+  A,
+  B,
+} ab;
+
+int main() {
+  return 0;
+}

--- a/examples/enum.c
+++ b/examples/enum.c
@@ -1,0 +1,8 @@
+enum AB {
+  A,
+  B,
+} ab;
+
+int main() {
+  return 0;
+}

--- a/src/domain/global_variable_view.rs
+++ b/src/domain/global_variable_view.rs
@@ -81,7 +81,18 @@ pub enum TypeView {
         element_type: Box<TypeView>,
         upper_bound: Option<usize>,
     },
+    Enum {
+        name: Option<String>,
+        type_view: Box<TypeView>,
+        enumerators: Vec<Enumerator>,
+    },
     Function,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Enumerator {
+    pub name: String,
+    pub value: usize,
 }
 
 impl TypeView {
@@ -128,6 +139,18 @@ impl TypeView {
         Self::Array {
             element_type: Box::new(element_type),
             upper_bound,
+        }
+    }
+
+    pub fn new_enum_type_view<S: Into<String>>(
+        name: Option<S>,
+        type_view: Self,
+        enumerators: Vec<Enumerator>,
+    ) -> Self {
+        Self::Enum {
+            name: name.map(S::into),
+            type_view: Box::new(type_view),
+            enumerators,
         }
     }
 

--- a/src/domain/global_variable_view.rs
+++ b/src/domain/global_variable_view.rs
@@ -1,4 +1,5 @@
 use super::global_variable::Address;
+use super::type_entry::EnumeratorEntry;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct GlobalVariableView {
@@ -93,6 +94,15 @@ pub enum TypeView {
 pub struct Enumerator {
     pub name: String,
     pub value: usize,
+}
+
+impl From<&EnumeratorEntry> for Enumerator {
+    fn from(entry: &EnumeratorEntry) -> Self {
+        Enumerator {
+            name: entry.name.clone(),
+            value: entry.value,
+        }
+    }
 }
 
 impl TypeView {

--- a/src/domain/global_variable_view_factory.rs
+++ b/src/domain/global_variable_view_factory.rs
@@ -55,6 +55,7 @@ impl<'repo> GlobalVariableViewFactory<'repo> {
                     type_name.clone(),
                     *size,
                 )),
+                TypeEntryKind::EnumType { .. } => unimplemented!(),
                 TypeEntryKind::StructureType {
                     name: type_name,
                     size,
@@ -285,6 +286,7 @@ impl<'repo> GlobalVariableViewFactory<'repo> {
                     type_name.clone(),
                     *size,
                 )),
+                TypeEntryKind::EnumType { .. } => unimplemented!(),
                 TypeEntryKind::StructureType {
                     name: type_name,
                     size,
@@ -578,6 +580,7 @@ impl<'repo> GlobalVariableViewFactory<'repo> {
                 TypeEntryKind::BaseType { name, .. } => {
                     Some(TypeView::new_base_type_view(name.clone()))
                 }
+                TypeEntryKind::EnumType { .. } => unimplemented!(),
                 TypeEntryKind::StructureType { name, .. } => {
                     Some(TypeView::new_structure_type_view(name.clone()))
                 }

--- a/src/domain/global_variable_view_factory.rs
+++ b/src/domain/global_variable_view_factory.rs
@@ -1,5 +1,5 @@
 use super::global_variable::{Address, GlobalVariable};
-use super::global_variable_view::{GlobalVariableView, TypeView};
+use super::global_variable_view::*;
 use super::type_entry::*;
 use super::type_entry_repository::TypeEntryRepository;
 use log::warn;
@@ -55,7 +55,16 @@ impl<'repo> GlobalVariableViewFactory<'repo> {
                     type_name.clone(),
                     *size,
                 )),
-                TypeEntryKind::EnumType { .. } => unimplemented!(),
+                TypeEntryKind::EnumType {
+                    name: type_name,
+                    type_ref,
+                    enumerators,
+                } => self.from_global_variable_enum_type(
+                    global_variable,
+                    type_name.clone(),
+                    type_ref.clone(),
+                    enumerators,
+                ),
                 TypeEntryKind::StructureType {
                     name: type_name,
                     size,
@@ -165,6 +174,26 @@ impl<'repo> GlobalVariableViewFactory<'repo> {
             TypeView::new_base_type_view(type_name),
             Vec::new(),
         )
+    }
+
+    fn from_global_variable_enum_type(
+        &self,
+        global_variable: GlobalVariable,
+        type_name: Option<String>,
+        type_ref: TypeEntryId,
+        enumerators: &Vec<EnumeratorEntry>,
+    ) -> Option<GlobalVariableView> {
+        let global_variable =
+            GlobalVariable::new(global_variable.address(), global_variable.name(), type_ref);
+
+        let mut global_variable_view = self.from_global_variable(global_variable)?;
+
+        let enumerators = enumerators.iter().map(Enumerator::from).collect();
+        global_variable_view.map_type_view(|type_view| {
+            TypeView::new_enum_type_view(type_name, type_view, enumerators)
+        });
+
+        Some(global_variable_view)
     }
 
     fn from_global_variable_structure_type(
@@ -286,7 +315,17 @@ impl<'repo> GlobalVariableViewFactory<'repo> {
                     type_name.clone(),
                     *size,
                 )),
-                TypeEntryKind::EnumType { .. } => unimplemented!(),
+                TypeEntryKind::EnumType {
+                    name: type_name,
+                    type_ref,
+                    enumerators,
+                } => self.from_structure_type_member_entry_enum_type(
+                    member,
+                    base_address,
+                    type_name.clone(),
+                    type_ref.clone(),
+                    enumerators,
+                ),
                 TypeEntryKind::StructureType {
                     name: type_name,
                     size,
@@ -419,6 +458,29 @@ impl<'repo> GlobalVariableViewFactory<'repo> {
             TypeView::new_base_type_view(type_name),
             Vec::new(),
         )
+    }
+
+    fn from_structure_type_member_entry_enum_type(
+        &self,
+        member: &StructureTypeMemberEntry,
+        base_address: &Option<Address>,
+        type_name: Option<String>,
+        type_ref: TypeEntryId,
+        enumerators: &Vec<EnumeratorEntry>,
+    ) -> Option<GlobalVariableView> {
+        let member = StructureTypeMemberEntry {
+            name: member.name.clone(),
+            location: member.location,
+            type_ref: type_ref,
+        };
+        let mut member_view = self.from_structure_type_member_entry(&member, base_address)?;
+
+        let enumerators = enumerators.iter().map(Enumerator::from).collect();
+        member_view.map_type_view(|type_view| {
+            TypeView::new_enum_type_view(type_name, type_view, enumerators)
+        });
+
+        Some(member_view)
     }
 
     fn from_structure_type_member_entry_structure_type(

--- a/src/domain/global_variables_extractor.rs
+++ b/src/domain/global_variables_extractor.rs
@@ -266,6 +266,8 @@ impl<'repo> GlobalVariablesExtractor<'repo> {
                         TypeEntry::new_function_type_entry(id, argument_type_ref, return_type_ref);
                     self.type_entry_repository.save(type_entry);
                 }
+                DwarfTag::DW_TAG_enumeration_type => unimplemented!(),
+                DwarfTag::DW_TAG_enumerator => unimplemented!(),
                 DwarfTag::DW_TAG_subrange_type => (),
                 DwarfTag::DW_TAG_formal_parameter => (),
                 DwarfTag::DW_TAG_unimplemented => (),

--- a/src/domain/global_variables_extractor.rs
+++ b/src/domain/global_variables_extractor.rs
@@ -127,6 +127,46 @@ impl<'repo> GlobalVariablesExtractor<'repo> {
                     let type_entry = TypeEntry::new_base_type_entry(id, name, size);
                     self.type_entry_repository.save(type_entry);
                 }
+                DwarfTag::DW_TAG_enumeration_type => {
+                    let id = TypeEntryId::new(entry.offset());
+                    let name = entry.name();
+                    let type_ref = match entry.type_offset() {
+                        Some(type_ref) => TypeEntryId::new(type_ref),
+                        None => {
+                            Self::warning_no_expected_attribute(
+                                "enumeration_type entry should have type",
+                                &entry,
+                            );
+                            continue;
+                        }
+                    };
+
+                    let enumerators = entry
+                        .children()
+                        .iter()
+                        .flat_map(|entry| {
+                            let name = entry.name().or_else(|| {
+                                Self::warning_no_expected_attribute(
+                                    "enumerator entry should have name",
+                                    &entry,
+                                );
+                                None
+                            })?;
+                            let value = entry.const_value().or_else(|| {
+                                Self::warning_no_expected_attribute(
+                                    "enumerator entry should have const_value",
+                                    &entry,
+                                );
+                                None
+                            })?;
+
+                            Some(EnumeratorEntry { name, value })
+                        })
+                        .collect();
+                    let type_entry =
+                        TypeEntry::new_enum_type_entry(id, name, type_ref, enumerators);
+                    self.type_entry_repository.save(type_entry);
+                }
                 DwarfTag::DW_TAG_structure_type => {
                     let id = TypeEntryId::new(entry.offset());
 
@@ -266,8 +306,7 @@ impl<'repo> GlobalVariablesExtractor<'repo> {
                         TypeEntry::new_function_type_entry(id, argument_type_ref, return_type_ref);
                     self.type_entry_repository.save(type_entry);
                 }
-                DwarfTag::DW_TAG_enumeration_type => unimplemented!(),
-                DwarfTag::DW_TAG_enumerator => unimplemented!(),
+                DwarfTag::DW_TAG_enumerator => (),
                 DwarfTag::DW_TAG_subrange_type => (),
                 DwarfTag::DW_TAG_formal_parameter => (),
                 DwarfTag::DW_TAG_unimplemented => (),

--- a/src/domain/type_entry.rs
+++ b/src/domain/type_entry.rs
@@ -38,6 +38,11 @@ pub enum TypeEntryKind {
         name: String,
         size: usize,
     },
+    EnumType {
+        name: Option<String>,
+        type_ref: TypeEntryId,
+        enumerators: Vec<EnumeratorEntry>,
+    },
     StructureType {
         name: Option<String>,
         size: usize,
@@ -56,6 +61,12 @@ pub enum TypeEntryKind {
         argument_type_ref: Vec<TypeEntryId>,
         return_type_ref: Option<TypeEntryId>,
     },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct EnumeratorEntry {
+    pub name: String,
+    pub value: usize,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -99,6 +110,20 @@ impl TypeEntry {
 
     pub fn new_base_type_entry(id: TypeEntryId, name: String, size: usize) -> TypeEntry {
         let kind = TypeEntryKind::BaseType { name, size };
+        TypeEntry { id, kind }
+    }
+
+    pub fn new_enum_type_entry(
+        id: TypeEntryId,
+        name: Option<String>,
+        type_ref: TypeEntryId,
+        enumerators: Vec<EnumeratorEntry>,
+    ) -> TypeEntry {
+        let kind = TypeEntryKind::EnumType {
+            name,
+            type_ref,
+            enumerators,
+        };
         TypeEntry { id, kind }
     }
 

--- a/src/infrastructure/fromelf/stdout.rs
+++ b/src/infrastructure/fromelf/stdout.rs
@@ -143,6 +143,7 @@ impl fmt::Display for TypeView {
             TypeView::Union { name } => {
                 write!(f, "union {}", name.as_ref().unwrap_or(&String::from("")))
             }
+            TypeView::Enum { .. } => "".fmt(f),
             TypeView::Array {
                 element_type,
                 upper_bound,

--- a/src/infrastructure/fromelf/stdout.rs
+++ b/src/infrastructure/fromelf/stdout.rs
@@ -1,5 +1,6 @@
-use crate::domain::global_variable_view::{GlobalVariableView, TypeView};
+use crate::domain::global_variable_view::*;
 use std::fmt;
+use std::fmt::Write;
 
 const ADDRESS_WIDTH: usize = 10;
 const SIZE_WIDTH: usize = 5;
@@ -143,7 +144,17 @@ impl fmt::Display for TypeView {
             TypeView::Union { name } => {
                 write!(f, "union {}", name.as_ref().unwrap_or(&String::from("")))
             }
-            TypeView::Enum { .. } => "".fmt(f),
+            TypeView::Enum {
+                name,
+                type_view,
+                enumerators,
+            } => format!(
+                "enum {}: {}  values = {}",
+                name.as_ref().unwrap_or(&String::from("")),
+                type_view,
+                Enumerators(enumerators)
+            )
+            .fmt(f),
             TypeView::Array {
                 element_type,
                 upper_bound,
@@ -153,5 +164,25 @@ impl fmt::Display for TypeView {
             },
             TypeView::Function {} => write!(f, "function"),
         }
+    }
+}
+
+impl fmt::Display for Enumerator {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        format!("{}: {}", self.name, self.value).fmt(f)
+    }
+}
+
+struct Enumerators<'a>(&'a Vec<Enumerator>);
+
+impl<'a> fmt::Display for Enumerators<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut out = String::new();
+
+        for enumerator in self.0 {
+            let _ = write!(&mut out, "{}, ", enumerator);
+        }
+
+        out.fmt(f)
     }
 }

--- a/tests/domain/global_variable_view_factory_test.rs
+++ b/tests/domain/global_variable_view_factory_test.rs
@@ -183,6 +183,118 @@ fn from_global_variable_array() {
 }
 
 #[test]
+fn from_global_variable_enum() {
+    let defined_types = vec![
+        TypeEntry::new_enum_type_entry(
+            TypeEntryId::new(Offset::new(45)),
+            Some(String::from("AB")),
+            TypeEntryId::new(Offset::new(71)),
+            vec![
+                EnumeratorEntry {
+                    name: String::from("A"),
+                    value: 0,
+                },
+                EnumeratorEntry {
+                    name: String::from("B"),
+                    value: 1,
+                },
+            ],
+        ),
+        TypeEntry::new_base_type_entry(
+            TypeEntryId::new(Offset::new(71)),
+            String::from("unsigned int"),
+            4,
+        ),
+        TypeEntry::new_base_type_entry(TypeEntryId::new(Offset::new(129)), String::from("int"), 4),
+    ];
+
+    let global_variable = GlobalVariable::new(
+        Some(Address::new(Location::new(16428))),
+        String::from("ab"),
+        TypeEntryId::new(Offset::new(45)),
+    );
+
+    let expected_view = GlobalVariableView::new(
+        String::from("ab"),
+        Some(Address::new(Location::new(16428))),
+        4,
+        TypeView::new_enum_type_view(
+            Some("AB"),
+            TypeView::new_base_type_view("unsigned int"),
+            vec![
+                Enumerator {
+                    name: String::from("A"),
+                    value: 0,
+                },
+                Enumerator {
+                    name: String::from("B"),
+                    value: 1,
+                },
+            ],
+        ),
+        vec![],
+    );
+
+    from_global_variable_test(defined_types, global_variable, expected_view);
+}
+
+#[test]
+fn from_global_variable_anonymous_enum() {
+    let defined_types = vec![
+        TypeEntry::new_enum_type_entry(
+            TypeEntryId::new(Offset::new(45)),
+            None,
+            TypeEntryId::new(Offset::new(68)),
+            vec![
+                EnumeratorEntry {
+                    name: String::from("A"),
+                    value: 0,
+                },
+                EnumeratorEntry {
+                    name: String::from("B"),
+                    value: 1,
+                },
+            ],
+        ),
+        TypeEntry::new_base_type_entry(
+            TypeEntryId::new(Offset::new(68)),
+            String::from("unsigned int"),
+            4,
+        ),
+        TypeEntry::new_base_type_entry(TypeEntryId::new(Offset::new(126)), String::from("int"), 4),
+    ];
+
+    let global_variable = GlobalVariable::new(
+        Some(Address::new(Location::new(16428))),
+        String::from("ab"),
+        TypeEntryId::new(Offset::new(45)),
+    );
+
+    let expected_view = GlobalVariableView::new(
+        String::from("ab"),
+        Some(Address::new(Location::new(16428))),
+        4,
+        TypeView::new_enum_type_view::<String>(
+            None,
+            TypeView::new_base_type_view("unsigned int"),
+            vec![
+                Enumerator {
+                    name: String::from("A"),
+                    value: 0,
+                },
+                Enumerator {
+                    name: String::from("B"),
+                    value: 1,
+                },
+            ],
+        ),
+        vec![],
+    );
+
+    from_global_variable_test(defined_types, global_variable, expected_view);
+}
+
+#[test]
 fn from_global_variable_structure() {
     let defined_types = vec![
         TypeEntry::new_structure_type_entry(

--- a/tests/domain/global_variables_extractor_test.rs
+++ b/tests/domain/global_variables_extractor_test.rs
@@ -327,6 +327,88 @@ fn extract_enum() {
 }
 
 #[test]
+fn extract_anonymous_enum() {
+    let infos = vec![
+        DwarfInfoBuilder::new()
+            .offset(Offset::new(45))
+            .tag(DwarfTag::DW_TAG_enumeration_type)
+            .byte_size(4)
+            .type_offset(Offset::new(68))
+            .children(vec![
+                DwarfInfoBuilder::new()
+                    .offset(Offset::new(59))
+                    .tag(DwarfTag::DW_TAG_enumerator)
+                    .name("A")
+                    .const_value(0)
+                    .build(),
+                DwarfInfoBuilder::new()
+                    .offset(Offset::new(63))
+                    .tag(DwarfTag::DW_TAG_enumerator)
+                    .name("B")
+                    .const_value(1)
+                    .build(),
+            ])
+            .build(),
+        DwarfInfoBuilder::new()
+            .offset(Offset::new(68))
+            .tag(DwarfTag::DW_TAG_base_type)
+            .byte_size(4)
+            .name("unsigned int")
+            .build(),
+        DwarfInfoBuilder::new()
+            .offset(Offset::new(75))
+            .tag(DwarfTag::DW_TAG_variable)
+            .name("ab")
+            .type_offset(Offset::new(45))
+            .location(Location::new(16428))
+            .build(),
+        DwarfInfoBuilder::new()
+            .offset(Offset::new(96))
+            .tag(DwarfTag::DW_TAG_unimplemented)
+            .name("main")
+            .type_offset(Offset::new(126))
+            .build(),
+        DwarfInfoBuilder::new()
+            .offset(Offset::new(126))
+            .tag(DwarfTag::DW_TAG_base_type)
+            .byte_size(4)
+            .name("int")
+            .build(),
+    ];
+
+    let expected_variables = vec![GlobalVariable::new(
+        Some(Address::new(Location::new(16428))),
+        String::from("ab"),
+        TypeEntryId::new(Offset::new(45)),
+    )];
+    let expected_types = vec![
+        TypeEntry::new_enum_type_entry(
+            TypeEntryId::new(Offset::new(45)),
+            None,
+            TypeEntryId::new(Offset::new(68)),
+            vec![
+                EnumeratorEntry {
+                    name: String::from("A"),
+                    value: 0,
+                },
+                EnumeratorEntry {
+                    name: String::from("B"),
+                    value: 1,
+                },
+            ],
+        ),
+        TypeEntry::new_base_type_entry(
+            TypeEntryId::new(Offset::new(68)),
+            String::from("unsigned int"),
+            4,
+        ),
+        TypeEntry::new_base_type_entry(TypeEntryId::new(Offset::new(126)), String::from("int"), 4),
+    ];
+
+    extract_test(infos, expected_variables, expected_types);
+}
+
+#[test]
 fn extract_structure() {
     let infos = vec![
         DwarfInfoBuilder::new()

--- a/tests/domain/global_variables_extractor_test.rs
+++ b/tests/domain/global_variables_extractor_test.rs
@@ -244,6 +244,89 @@ fn extract_array() {
 }
 
 #[test]
+fn extract_enum() {
+    let infos = vec![
+        DwarfInfoBuilder::new()
+            .offset(Offset::new(45))
+            .tag(DwarfTag::DW_TAG_enumeration_type)
+            .name("AB")
+            .byte_size(4)
+            .type_offset(Offset::new(71))
+            .children(vec![
+                DwarfInfoBuilder::new()
+                    .offset(Offset::new(62))
+                    .tag(DwarfTag::DW_TAG_enumerator)
+                    .name("A")
+                    .const_value(0)
+                    .build(),
+                DwarfInfoBuilder::new()
+                    .offset(Offset::new(66))
+                    .tag(DwarfTag::DW_TAG_enumerator)
+                    .name("B")
+                    .const_value(1)
+                    .build(),
+            ])
+            .build(),
+        DwarfInfoBuilder::new()
+            .offset(Offset::new(71))
+            .tag(DwarfTag::DW_TAG_base_type)
+            .byte_size(4)
+            .name("unsigned int")
+            .build(),
+        DwarfInfoBuilder::new()
+            .offset(Offset::new(78))
+            .tag(DwarfTag::DW_TAG_variable)
+            .name("ab")
+            .type_offset(Offset::new(45))
+            .location(Location::new(16428))
+            .build(),
+        DwarfInfoBuilder::new()
+            .offset(Offset::new(99))
+            .tag(DwarfTag::DW_TAG_unimplemented)
+            .name("main")
+            .type_offset(Offset::new(129))
+            .build(),
+        DwarfInfoBuilder::new()
+            .offset(Offset::new(129))
+            .tag(DwarfTag::DW_TAG_base_type)
+            .byte_size(4)
+            .name("int")
+            .build(),
+    ];
+
+    let expected_variables = vec![GlobalVariable::new(
+        Some(Address::new(Location::new(16428))),
+        String::from("ab"),
+        TypeEntryId::new(Offset::new(45)),
+    )];
+    let expected_types = vec![
+        TypeEntry::new_enum_type_entry(
+            TypeEntryId::new(Offset::new(45)),
+            Some(String::from("AB")),
+            TypeEntryId::new(Offset::new(71)),
+            vec![
+                EnumeratorEntry {
+                    name: String::from("A"),
+                    value: 0,
+                },
+                EnumeratorEntry {
+                    name: String::from("B"),
+                    value: 1,
+                },
+            ],
+        ),
+        TypeEntry::new_base_type_entry(
+            TypeEntryId::new(Offset::new(71)),
+            String::from("unsigned int"),
+            4,
+        ),
+        TypeEntry::new_base_type_entry(TypeEntryId::new(Offset::new(129)), String::from("int"), 4),
+    ];
+
+    extract_test(infos, expected_variables, expected_types);
+}
+
+#[test]
 fn extract_structure() {
     let infos = vec![
         DwarfInfoBuilder::new()

--- a/tests/library/dwarf_test.rs
+++ b/tests/library/dwarf_test.rs
@@ -224,6 +224,60 @@ fn dwarf_info_enum() {
 
 #[test]
 #[ignore]
+fn dwarf_info_anonymous_enum() {
+    let expected = vec![
+        DwarfInfoBuilder::new()
+            .offset(Offset::new(45))
+            .tag(DwarfTag::DW_TAG_enumeration_type)
+            .byte_size(4)
+            .type_offset(Offset::new(68))
+            .children(vec![
+                DwarfInfoBuilder::new()
+                    .offset(Offset::new(59))
+                    .tag(DwarfTag::DW_TAG_enumerator)
+                    .name("A")
+                    .const_value(0)
+                    .build(),
+                DwarfInfoBuilder::new()
+                    .offset(Offset::new(63))
+                    .tag(DwarfTag::DW_TAG_enumerator)
+                    .name("B")
+                    .const_value(1)
+                    .build(),
+            ])
+            .build(),
+        DwarfInfoBuilder::new()
+            .offset(Offset::new(68))
+            .tag(DwarfTag::DW_TAG_base_type)
+            .byte_size(4)
+            .name("unsigned int")
+            .build(),
+        DwarfInfoBuilder::new()
+            .offset(Offset::new(75))
+            .tag(DwarfTag::DW_TAG_variable)
+            .name("ab")
+            .type_offset(Offset::new(45))
+            .location(Location::new(16428))
+            .build(),
+        DwarfInfoBuilder::new()
+            .offset(Offset::new(96))
+            .tag(DwarfTag::DW_TAG_unimplemented)
+            .name("main")
+            .type_offset(Offset::new(126))
+            .build(),
+        DwarfInfoBuilder::new()
+            .offset(Offset::new(126))
+            .tag(DwarfTag::DW_TAG_base_type)
+            .byte_size(4)
+            .name("int")
+            .build(),
+    ];
+
+    dwarf_info_intoiterator_test("examples/anonymous-enum", expected);
+}
+
+#[test]
+#[ignore]
 fn dwarf_info_structure() {
     let expected = vec![
         DwarfInfoBuilder::new()

--- a/tests/library/dwarf_test.rs
+++ b/tests/library/dwarf_test.rs
@@ -169,6 +169,61 @@ fn dwarf_info_array() {
 
 #[test]
 #[ignore]
+fn dwarf_info_enum() {
+    let expected = vec![
+        DwarfInfoBuilder::new()
+            .offset(Offset::new(45))
+            .tag(DwarfTag::DW_TAG_enumeration_type)
+            .name("AB")
+            .byte_size(4)
+            .type_offset(Offset::new(71))
+            .children(vec![
+                DwarfInfoBuilder::new()
+                    .offset(Offset::new(62))
+                    .tag(DwarfTag::DW_TAG_enumerator)
+                    .name("A")
+                    .const_value(0)
+                    .build(),
+                DwarfInfoBuilder::new()
+                    .offset(Offset::new(66))
+                    .tag(DwarfTag::DW_TAG_enumerator)
+                    .name("B")
+                    .const_value(1)
+                    .build(),
+            ])
+            .build(),
+        DwarfInfoBuilder::new()
+            .offset(Offset::new(71))
+            .tag(DwarfTag::DW_TAG_base_type)
+            .byte_size(4)
+            .name("unsigned int")
+            .build(),
+        DwarfInfoBuilder::new()
+            .offset(Offset::new(78))
+            .tag(DwarfTag::DW_TAG_variable)
+            .name("ab")
+            .type_offset(Offset::new(45))
+            .location(Location::new(16428))
+            .build(),
+        DwarfInfoBuilder::new()
+            .offset(Offset::new(99))
+            .tag(DwarfTag::DW_TAG_unimplemented)
+            .name("main")
+            .type_offset(Offset::new(129))
+            .build(),
+        DwarfInfoBuilder::new()
+            .offset(Offset::new(129))
+            .tag(DwarfTag::DW_TAG_base_type)
+            .byte_size(4)
+            .name("int")
+            .build(),
+    ];
+
+    dwarf_info_intoiterator_test("examples/enum", expected);
+}
+
+#[test]
+#[ignore]
 fn dwarf_info_structure() {
     let expected = vec![
         DwarfInfoBuilder::new()


### PR DESCRIPTION
## Why
#43 

## What
- Add examples for enum and anonymous enum
- Support enum
- Output format is the most simple one.
  - just `  enum AB: unsigned int  values = A: 0, B: 1, `