### PR TITLE
Support union bit field

### DIFF
--- a/examples/union.c
+++ b/examples/union.c
@@ -1,6 +1,6 @@
 union book {
   char name;
-  int price;
+  int price: 8;
 } book;
 
 

--- a/src/domain/global_variables_extractor.rs
+++ b/src/domain/global_variables_extractor.rs
@@ -292,7 +292,12 @@ impl<'type_repo, 'dec_repo> GlobalVariablesExtractor<'type_repo, 'dec_repo> {
                     }
                 }?;
 
-                Some(UnionTypeMemberEntry { name, type_ref })
+                let bit_size = entry.bit_size();
+                let bit_offset = entry.bit_offset();
+
+                Some(UnionTypeMemberEntry::new(
+                    name, type_ref, bit_size, bit_offset,
+                ))
             })
             .collect();
         Ok(TypeEntry::new_union_type_entry(id, name, size, members))

--- a/src/domain/type_entry.rs
+++ b/src/domain/type_entry.rs
@@ -77,12 +77,6 @@ pub struct EnumeratorEntry {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct UnionTypeMemberEntry {
-    pub name: String,
-    pub type_ref: TypeEntryId,
-}
-
-#[derive(Debug, Clone, PartialEq)]
 pub struct TypeEntry {
     id: TypeEntryId,
     pub kind: TypeEntryKind,
@@ -214,7 +208,7 @@ pub struct MemberEntry<T> {
 #[derive(Debug, Clone, PartialEq)]
 pub struct StructureTypeMemberEntry(MemberEntry<Structure>);
 #[derive(Debug, Clone, PartialEq)]
-pub struct UnionTypeMemberEntry_(MemberEntry<Union>);
+pub struct UnionTypeMemberEntry(MemberEntry<Union>);
 
 impl StructureTypeMemberEntry {
     pub fn new(
@@ -242,8 +236,51 @@ impl From<MemberEntry<Structure>> for StructureTypeMemberEntry {
     }
 }
 
+impl Into<MemberEntry<Structure>> for StructureTypeMemberEntry {
+    fn into(self) -> MemberEntry<Structure> {
+        self.0
+    }
+}
+
 impl Deref for StructureTypeMemberEntry {
     type Target = MemberEntry<Structure>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl UnionTypeMemberEntry {
+    pub fn new(
+        name: String,
+        type_ref: TypeEntryId,
+        bit_size: Option<usize>,
+        bit_offset: Option<usize>,
+    ) -> Self {
+        Self(
+            MemberEntryBuilder::new_union()
+                .name(name)
+                .type_ref(type_ref)
+                .bit_size(bit_size)
+                .bit_offset(bit_offset)
+                .build(),
+        )
+    }
+}
+
+impl From<MemberEntry<Union>> for UnionTypeMemberEntry {
+    fn from(entry: MemberEntry<Union>) -> Self {
+        Self(entry)
+    }
+}
+
+impl Into<MemberEntry<Union>> for UnionTypeMemberEntry {
+    fn into(self) -> MemberEntry<Union> {
+        self.0
+    }
+}
+
+impl Deref for UnionTypeMemberEntry {
+    type Target = MemberEntry<Union>;
     fn deref(&self) -> &Self::Target {
         &self.0
     }

--- a/src/domain/type_entry.rs
+++ b/src/domain/type_entry.rs
@@ -1,3 +1,6 @@
+use std::marker::PhantomData;
+use std::ops::Deref;
+
 use super::entity::Entity;
 use crate::library::dwarf;
 
@@ -71,33 +74,6 @@ pub enum TypeEntryKind {
 pub struct EnumeratorEntry {
     pub name: String,
     pub value: usize,
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub struct StructureTypeMemberEntry {
-    pub name: String,
-    pub location: usize,
-    pub type_ref: TypeEntryId,
-    pub bit_size: Option<usize>,
-    pub bit_offset: Option<usize>,
-}
-
-impl StructureTypeMemberEntry {
-    pub fn new(
-        name: String,
-        location: usize,
-        type_ref: TypeEntryId,
-        bit_size: Option<usize>,
-        bit_offset: Option<usize>,
-    ) -> StructureTypeMemberEntry {
-        StructureTypeMemberEntry {
-            name,
-            location,
-            type_ref,
-            bit_size,
-            bit_offset,
-        }
-    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -221,97 +197,162 @@ impl Entity for TypeEntry {
     }
 }
 
-pub struct StructureTypeMemberEntryBuilder<NameP, LocationP, TypeRefP> {
+#[derive(Debug, Clone, PartialEq)]
+pub struct Structure;
+#[derive(Debug, Clone, PartialEq)]
+pub struct Union;
+#[derive(Debug, Clone, PartialEq)]
+pub struct MemberEntry<T> {
+    pub name: String,
+    pub location: usize,
+    pub type_ref: TypeEntryId,
+    pub bit_size: Option<usize>,
+    pub bit_offset: Option<usize>,
+    _phantom: PhantomData<T>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct StructureTypeMemberEntry(MemberEntry<Structure>);
+#[derive(Debug, Clone, PartialEq)]
+pub struct UnionTypeMemberEntry_(MemberEntry<Union>);
+
+impl StructureTypeMemberEntry {
+    pub fn new(
+        name: String,
+        location: usize,
+        type_ref: TypeEntryId,
+        bit_size: Option<usize>,
+        bit_offset: Option<usize>,
+    ) -> Self {
+        Self(
+            MemberEntryBuilder::new_structure()
+                .name(name)
+                .location(location)
+                .type_ref(type_ref)
+                .bit_size(bit_size)
+                .bit_offset(bit_offset)
+                .build(),
+        )
+    }
+}
+
+impl From<MemberEntry<Structure>> for StructureTypeMemberEntry {
+    fn from(entry: MemberEntry<Structure>) -> Self {
+        Self(entry)
+    }
+}
+
+impl Deref for StructureTypeMemberEntry {
+    type Target = MemberEntry<Structure>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+pub struct MemberEntryBuilder<NameP, LocationP, TypeRefP, T> {
     name: NameP,
     location: LocationP,
     type_ref: TypeRefP,
     bit_size: Option<usize>,
     bit_offset: Option<usize>,
+    _phantom: PhantomData<T>,
 }
 
-impl StructureTypeMemberEntryBuilder<(), (), ()> {
-    pub fn new() -> Self {
-        StructureTypeMemberEntryBuilder {
+impl MemberEntryBuilder<(), (), (), Structure> {
+    pub fn new_structure() -> Self {
+        Self {
             name: (),
             location: (),
             type_ref: (),
             bit_size: None,
             bit_offset: None,
+            _phantom: PhantomData,
         }
     }
 }
 
-impl StructureTypeMemberEntryBuilder<String, usize, TypeEntryId> {
-    pub fn build(self) -> StructureTypeMemberEntry {
-        StructureTypeMemberEntry {
+impl MemberEntryBuilder<(), usize, (), Union> {
+    pub fn new_union() -> Self {
+        Self {
+            name: (),
+            location: 0,
+            type_ref: (),
+            bit_size: None,
+            bit_offset: None,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<T> MemberEntryBuilder<String, usize, TypeEntryId, T> {
+    pub fn build(self) -> MemberEntry<T> {
+        MemberEntry {
             name: self.name,
             location: self.location,
             type_ref: self.type_ref,
             bit_size: self.bit_size,
             bit_offset: self.bit_offset,
+            _phantom: PhantomData,
         }
     }
 }
 
-impl<LocationP, TypeRefP> StructureTypeMemberEntryBuilder<(), LocationP, TypeRefP> {
+impl<LocationP, TypeRefP, T> MemberEntryBuilder<(), LocationP, TypeRefP, T> {
     pub fn name<S: Into<String>>(
         self,
         name: S,
-    ) -> StructureTypeMemberEntryBuilder<String, LocationP, TypeRefP> {
-        StructureTypeMemberEntryBuilder {
+    ) -> MemberEntryBuilder<String, LocationP, TypeRefP, T> {
+        MemberEntryBuilder {
             name: name.into(),
             location: self.location,
             type_ref: self.type_ref,
             bit_size: self.bit_size,
             bit_offset: self.bit_offset,
+            _phantom: PhantomData,
         }
     }
 }
 
-impl<NameP, TypeRefP> StructureTypeMemberEntryBuilder<NameP, (), TypeRefP> {
+impl<NameP, TypeRefP> MemberEntryBuilder<NameP, (), TypeRefP, Structure> {
     pub fn location(
         self,
         location: usize,
-    ) -> StructureTypeMemberEntryBuilder<NameP, usize, TypeRefP> {
-        StructureTypeMemberEntryBuilder {
+    ) -> MemberEntryBuilder<NameP, usize, TypeRefP, Structure> {
+        MemberEntryBuilder {
             name: self.name,
             location: location,
             type_ref: self.type_ref,
             bit_size: self.bit_size,
             bit_offset: self.bit_offset,
+            _phantom: PhantomData,
         }
     }
 }
 
-impl<NameP, LocationP> StructureTypeMemberEntryBuilder<NameP, LocationP, ()> {
+impl<NameP, LocationP, T> MemberEntryBuilder<NameP, LocationP, (), T> {
     pub fn type_ref(
         self,
         type_ref: TypeEntryId,
-    ) -> StructureTypeMemberEntryBuilder<NameP, LocationP, TypeEntryId> {
-        StructureTypeMemberEntryBuilder {
+    ) -> MemberEntryBuilder<NameP, LocationP, TypeEntryId, T> {
+        MemberEntryBuilder {
             name: self.name,
             location: self.location,
             type_ref: type_ref,
             bit_size: self.bit_size,
             bit_offset: self.bit_offset,
+            _phantom: PhantomData,
         }
     }
 }
 
-impl<NameP, LocationP, TypeRefP> StructureTypeMemberEntryBuilder<NameP, LocationP, TypeRefP> {
-    pub fn bit_size(
-        mut self,
-        size: usize,
-    ) -> StructureTypeMemberEntryBuilder<NameP, LocationP, TypeRefP> {
-        self.bit_size = Some(size);
+impl<NameP, LocationP, TypeRefP, T> MemberEntryBuilder<NameP, LocationP, TypeRefP, T> {
+    pub fn bit_size(mut self, size: Option<usize>) -> Self {
+        self.bit_size = size;
         self
     }
 
-    pub fn bit_offset(
-        mut self,
-        offset: usize,
-    ) -> StructureTypeMemberEntryBuilder<NameP, LocationP, TypeRefP> {
-        self.bit_offset = Some(offset);
+    pub fn bit_offset(mut self, offset: Option<usize>) -> Self {
+        self.bit_offset = offset;
         self
     }
 }

--- a/tests/domain/global_variable_view_factory_test.rs
+++ b/tests/domain/global_variable_view_factory_test.rs
@@ -398,18 +398,24 @@ fn from_global_variable_union() {
             Some(String::from("book")),
             4,
             vec![
-                UnionTypeMemberEntry {
-                    name: String::from("name"),
-                    type_ref: TypeEntryId::new(Offset::new(83)),
-                },
-                UnionTypeMemberEntry {
-                    name: String::from("price"),
-                    type_ref: TypeEntryId::new(Offset::new(90)),
-                },
+                UnionTypeMemberEntry::from(
+                    MemberEntryBuilder::new_union()
+                        .name("name")
+                        .type_ref(TypeEntryId::new(Offset::new(86)))
+                        .build(),
+                ),
+                UnionTypeMemberEntry::from(
+                    MemberEntryBuilder::new_union()
+                        .name("price")
+                        .type_ref(TypeEntryId::new(Offset::new(93)))
+                        .bit_size(Some(8))
+                        .bit_offset(Some(24))
+                        .build(),
+                ),
             ],
         ),
-        TypeEntry::new_base_type_entry(TypeEntryId::new(Offset::new(83)), String::from("char"), 1),
-        TypeEntry::new_base_type_entry(TypeEntryId::new(Offset::new(90)), String::from("int"), 4),
+        TypeEntry::new_base_type_entry(TypeEntryId::new(Offset::new(86)), String::from("char"), 1),
+        TypeEntry::new_base_type_entry(TypeEntryId::new(Offset::new(93)), String::from("int"), 4),
     ];
 
     let global_variable = GlobalVariable::new_variable(
@@ -434,6 +440,8 @@ fn from_global_variable_union() {
                 .name("price")
                 .address(Some(Address::new(Location::new(16428))))
                 .size(4)
+                .bit_size(Some(8))
+                .bit_offset(Some(24))
                 .type_view(TypeView::new_base_type_view("int"))
                 .build(),
         ])
@@ -463,14 +471,18 @@ fn from_global_variable_anonymous_union_structure() {
             None,
             4,
             vec![
-                UnionTypeMemberEntry {
-                    name: String::from("a"),
-                    type_ref: TypeEntryId::new(Offset::new(66)),
-                },
-                UnionTypeMemberEntry {
-                    name: String::from("b"),
-                    type_ref: TypeEntryId::new(Offset::new(123)),
-                },
+                UnionTypeMemberEntry::from(
+                    MemberEntryBuilder::new_union()
+                        .name("a")
+                        .type_ref(TypeEntryId::new(Offset::new(66)))
+                        .build(),
+                ),
+                UnionTypeMemberEntry::from(
+                    MemberEntryBuilder::new_union()
+                        .name("b")
+                        .type_ref(TypeEntryId::new(Offset::new(123)))
+                        .build(),
+                ),
             ],
         ),
         TypeEntry::new_base_type_entry(TypeEntryId::new(Offset::new(123)), String::from("char"), 1),

--- a/tests/domain/global_variable_view_factory_test.rs
+++ b/tests/domain/global_variable_view_factory_test.rs
@@ -318,23 +318,29 @@ fn from_global_variable_structure() {
             Some(String::from("hoge")),
             8,
             vec![
-                StructureTypeMemberEntryBuilder::new()
-                    .name("hoge")
-                    .location(0)
-                    .type_ref(TypeEntryId::new(Offset::new(101)))
-                    .build(),
-                StructureTypeMemberEntryBuilder::new()
-                    .name("fuga")
-                    .location(4)
-                    .type_ref(TypeEntryId::new(Offset::new(108)))
-                    .build(),
-                StructureTypeMemberEntryBuilder::new()
-                    .name("pohe")
-                    .location(4)
-                    .type_ref(TypeEntryId::new(Offset::new(115)))
-                    .bit_size(1)
-                    .bit_offset(23)
-                    .build(),
+                StructureTypeMemberEntry::from(
+                    MemberEntryBuilder::new_structure()
+                        .name("hoge")
+                        .location(0)
+                        .type_ref(TypeEntryId::new(Offset::new(101)))
+                        .build(),
+                ),
+                StructureTypeMemberEntry::from(
+                    MemberEntryBuilder::new_structure()
+                        .name("fuga")
+                        .location(4)
+                        .type_ref(TypeEntryId::new(Offset::new(108)))
+                        .build(),
+                ),
+                StructureTypeMemberEntry::from(
+                    MemberEntryBuilder::new_structure()
+                        .name("pohe")
+                        .location(4)
+                        .type_ref(TypeEntryId::new(Offset::new(115)))
+                        .bit_size(Some(1))
+                        .bit_offset(Some(23))
+                        .build(),
+                ),
             ],
         ),
         TypeEntry::new_base_type_entry(TypeEntryId::new(Offset::new(101)), String::from("int"), 4),
@@ -443,11 +449,13 @@ fn from_global_variable_anonymous_union_structure() {
             TypeEntryId::new(Offset::new(45)),
             None,
             4,
-            vec![StructureTypeMemberEntryBuilder::new()
-                .name("a")
-                .type_ref(TypeEntryId::new(Offset::new(66)))
-                .location(0)
-                .build()],
+            vec![StructureTypeMemberEntry::from(
+                MemberEntryBuilder::new_structure()
+                    .name("a")
+                    .type_ref(TypeEntryId::new(Offset::new(66)))
+                    .location(0)
+                    .build(),
+            )],
         ),
         TypeEntry::new_base_type_entry(TypeEntryId::new(Offset::new(66)), String::from("int"), 4),
         TypeEntry::new_union_type_entry(
@@ -515,43 +523,6 @@ fn from_global_variable_anonymous_union_structure() {
             ])
             .build(),
     ];
-    // let expected_views = vec![
-    //     GlobalVariableView::new(
-    //         String::from("a"),
-    //         Some(Address::new(Location::new(16428))),
-    //         4,
-    //         TypeView::new_structure_type_view::<String>(None),
-    //         vec![GlobalVariableView::new(
-    //             String::from("a"),
-    //             Some(Address::new(Location::new(16428))),
-    //             4,
-    //             TypeView::new_base_type_view("int"),
-    //             vec![],
-    //         )],
-    //     ),
-    //     GlobalVariableView::new(
-    //         String::from("ab"),
-    //         Some(Address::new(Location::new(16432))),
-    //         4,
-    //         TypeView::new_union_type_view::<String>(None),
-    //         vec![
-    //             GlobalVariableView::new(
-    //                 String::from("a"),
-    //                 Some(Address::new(Location::new(16432))),
-    //                 4,
-    //                 TypeView::new_base_type_view("int"),
-    //                 vec![],
-    //             ),
-    //             GlobalVariableView::new(
-    //                 String::from("b"),
-    //                 Some(Address::new(Location::new(16432))),
-    //                 1,
-    //                 TypeView::new_base_type_view("char"),
-    //                 vec![],
-    //             ),
-    //         ],
-    //     ),
-    // ];
 
     from_global_variables_test(defined_types, Vec::new(), global_variables, expected_views);
 }
@@ -601,11 +572,13 @@ fn from_global_variable_complex_structure() {
             TypeEntryId::new(Offset::new(45)),
             Some(String::from("student")),
             4,
-            vec![StructureTypeMemberEntryBuilder::new()
-                .name("name")
-                .location(0)
-                .type_ref(TypeEntryId::new(Offset::new(72)))
-                .build()],
+            vec![StructureTypeMemberEntry::from(
+                MemberEntryBuilder::new_structure()
+                    .name("name")
+                    .location(0)
+                    .type_ref(TypeEntryId::new(Offset::new(72)))
+                    .build(),
+            )],
         ),
         TypeEntry::new_array_type_entry(
             TypeEntryId::new(Offset::new(72)),
@@ -623,21 +596,27 @@ fn from_global_variable_complex_structure() {
             Some(String::from("hoge")),
             24,
             vec![
-                StructureTypeMemberEntryBuilder::new()
-                    .name("hoge")
-                    .location(0)
-                    .type_ref(TypeEntryId::new(Offset::new(155)))
-                    .build(),
-                StructureTypeMemberEntryBuilder::new()
-                    .name("array")
-                    .location(8)
-                    .type_ref(TypeEntryId::new(Offset::new(168)))
-                    .build(),
-                StructureTypeMemberEntryBuilder::new()
-                    .name("student")
-                    .location(16)
-                    .type_ref(TypeEntryId::new(Offset::new(45)))
-                    .build(),
+                StructureTypeMemberEntry::from(
+                    MemberEntryBuilder::new_structure()
+                        .name("hoge")
+                        .location(0)
+                        .type_ref(TypeEntryId::new(Offset::new(155)))
+                        .build(),
+                ),
+                StructureTypeMemberEntry::from(
+                    MemberEntryBuilder::new_structure()
+                        .name("array")
+                        .location(8)
+                        .type_ref(TypeEntryId::new(Offset::new(168)))
+                        .build(),
+                ),
+                StructureTypeMemberEntry::from(
+                    MemberEntryBuilder::new_structure()
+                        .name("student")
+                        .location(16)
+                        .type_ref(TypeEntryId::new(Offset::new(45)))
+                        .build(),
+                ),
             ],
         ),
         TypeEntry::new_pointer_type_entry(

--- a/tests/domain/global_variables_extractor_test.rs
+++ b/tests/domain/global_variables_extractor_test.rs
@@ -557,7 +557,7 @@ fn extract_union() {
                     .name("price")
                     .type_offset(Offset::new(93))
                     .byte_size(4)
-                    .bit_offset(8)
+                    .bit_size(8)
                     .bit_offset(24)
                     .build(),
             ])
@@ -601,14 +601,20 @@ fn extract_union() {
             Some(String::from("book")),
             4,
             vec![
-                UnionTypeMemberEntry {
-                    name: String::from("name"),
-                    type_ref: TypeEntryId::new(Offset::new(86)),
-                },
-                UnionTypeMemberEntry {
-                    name: String::from("price"),
-                    type_ref: TypeEntryId::new(Offset::new(93)),
-                },
+                UnionTypeMemberEntry::from(
+                    MemberEntryBuilder::new_union()
+                        .name("name")
+                        .type_ref(TypeEntryId::new(Offset::new(86)))
+                        .build(),
+                ),
+                UnionTypeMemberEntry::from(
+                    MemberEntryBuilder::new_union()
+                        .name("price")
+                        .type_ref(TypeEntryId::new(Offset::new(93)))
+                        .bit_size(Some(8))
+                        .bit_offset(Some(24))
+                        .build(),
+                ),
             ],
         ),
         TypeEntry::new_base_type_entry(TypeEntryId::new(Offset::new(86)), String::from("char"), 1),
@@ -718,14 +724,18 @@ fn extract_anonymous_union_structure() {
             None,
             4,
             vec![
-                UnionTypeMemberEntry {
-                    name: String::from("a"),
-                    type_ref: TypeEntryId::new(Offset::new(66)),
-                },
-                UnionTypeMemberEntry {
-                    name: String::from("b"),
-                    type_ref: TypeEntryId::new(Offset::new(123)),
-                },
+                UnionTypeMemberEntry::from(
+                    MemberEntryBuilder::new_union()
+                        .name("a")
+                        .type_ref(TypeEntryId::new(Offset::new(66)))
+                        .build(),
+                ),
+                UnionTypeMemberEntry::from(
+                    MemberEntryBuilder::new_union()
+                        .name("b")
+                        .type_ref(TypeEntryId::new(Offset::new(123)))
+                        .build(),
+                ),
             ],
         ),
         TypeEntry::new_base_type_entry(TypeEntryId::new(Offset::new(123)), String::from("char"), 1),

--- a/tests/domain/global_variables_extractor_test.rs
+++ b/tests/domain/global_variables_extractor_test.rs
@@ -499,23 +499,29 @@ fn extract_structure() {
             Some(String::from("hoge")),
             8,
             vec![
-                StructureTypeMemberEntryBuilder::new()
-                    .name("hoge")
-                    .location(0)
-                    .type_ref(TypeEntryId::new(Offset::new(101)))
-                    .build(),
-                StructureTypeMemberEntryBuilder::new()
-                    .name("fuga")
-                    .location(4)
-                    .type_ref(TypeEntryId::new(Offset::new(108)))
-                    .build(),
-                StructureTypeMemberEntryBuilder::new()
-                    .name("pohe")
-                    .location(4)
-                    .type_ref(TypeEntryId::new(Offset::new(115)))
-                    .bit_size(1)
-                    .bit_offset(23)
-                    .build(),
+                StructureTypeMemberEntry::from(
+                    MemberEntryBuilder::new_structure()
+                        .name("hoge")
+                        .location(0)
+                        .type_ref(TypeEntryId::new(Offset::new(101)))
+                        .build(),
+                ),
+                StructureTypeMemberEntry::from(
+                    MemberEntryBuilder::new_structure()
+                        .name("fuga")
+                        .location(4)
+                        .type_ref(TypeEntryId::new(Offset::new(108)))
+                        .build(),
+                ),
+                StructureTypeMemberEntry::from(
+                    MemberEntryBuilder::new_structure()
+                        .name("pohe")
+                        .location(4)
+                        .type_ref(TypeEntryId::new(Offset::new(115)))
+                        .bit_size(Some(1))
+                        .bit_offset(Some(23))
+                        .build(),
+                ),
             ],
         ),
         TypeEntry::new_base_type_entry(TypeEntryId::new(Offset::new(101)), String::from("int"), 4),
@@ -698,11 +704,13 @@ fn extract_anonymous_union_structure() {
             TypeEntryId::new(Offset::new(45)),
             None,
             4,
-            vec![StructureTypeMemberEntryBuilder::new()
-                .name("a")
-                .type_ref(TypeEntryId::new(Offset::new(66)))
-                .location(0)
-                .build()],
+            vec![StructureTypeMemberEntry::from(
+                MemberEntryBuilder::new_structure()
+                    .name("a")
+                    .type_ref(TypeEntryId::new(Offset::new(66)))
+                    .location(0)
+                    .build(),
+            )],
         ),
         TypeEntry::new_base_type_entry(TypeEntryId::new(Offset::new(66)), String::from("int"), 4),
         TypeEntry::new_union_type_entry(
@@ -952,11 +960,13 @@ fn extract_complex_structure() {
             TypeEntryId::new(Offset::new(45)),
             Some(String::from("student")),
             4,
-            vec![StructureTypeMemberEntryBuilder::new()
-                .name("name")
-                .location(0)
-                .type_ref(TypeEntryId::new(Offset::new(72)))
-                .build()],
+            vec![StructureTypeMemberEntry::from(
+                MemberEntryBuilder::new_structure()
+                    .name("name")
+                    .location(0)
+                    .type_ref(TypeEntryId::new(Offset::new(72)))
+                    .build(),
+            )],
         ),
         TypeEntry::new_array_type_entry(
             TypeEntryId::new(Offset::new(72)),
@@ -974,21 +984,27 @@ fn extract_complex_structure() {
             Some(String::from("hoge")),
             24,
             vec![
-                StructureTypeMemberEntryBuilder::new()
-                    .name("hoge")
-                    .location(0)
-                    .type_ref(TypeEntryId::new(Offset::new(155)))
-                    .build(),
-                StructureTypeMemberEntryBuilder::new()
-                    .name("array")
-                    .location(8)
-                    .type_ref(TypeEntryId::new(Offset::new(168)))
-                    .build(),
-                StructureTypeMemberEntryBuilder::new()
-                    .name("student")
-                    .location(16)
-                    .type_ref(TypeEntryId::new(Offset::new(45)))
-                    .build(),
+                StructureTypeMemberEntry::from(
+                    MemberEntryBuilder::new_structure()
+                        .name("hoge")
+                        .location(0)
+                        .type_ref(TypeEntryId::new(Offset::new(155)))
+                        .build(),
+                ),
+                StructureTypeMemberEntry::from(
+                    MemberEntryBuilder::new_structure()
+                        .name("array")
+                        .location(8)
+                        .type_ref(TypeEntryId::new(Offset::new(168)))
+                        .build(),
+                ),
+                StructureTypeMemberEntry::from(
+                    MemberEntryBuilder::new_structure()
+                        .name("student")
+                        .location(16)
+                        .type_ref(TypeEntryId::new(Offset::new(45)))
+                        .build(),
+                ),
             ],
         ),
         TypeEntry::new_pointer_type_entry(

--- a/tests/domain/global_variables_extractor_test.rs
+++ b/tests/domain/global_variables_extractor_test.rs
@@ -543,40 +543,43 @@ fn extract_union() {
                     .offset(Offset::new(58))
                     .tag(DwarfTag::DW_TAG_unimplemented)
                     .name("name")
-                    .type_offset(Offset::new(83))
+                    .type_offset(Offset::new(86))
                     .build(),
                 DwarfInfoBuilder::new()
                     .offset(Offset::new(70))
                     .tag(DwarfTag::DW_TAG_unimplemented)
                     .name("price")
-                    .type_offset(Offset::new(90))
+                    .type_offset(Offset::new(93))
+                    .byte_size(4)
+                    .bit_offset(8)
+                    .bit_offset(24)
                     .build(),
             ])
             .build(),
         DwarfInfoBuilder::new()
-            .offset(Offset::new(83))
+            .offset(Offset::new(86))
             .tag(DwarfTag::DW_TAG_base_type)
             .byte_size(1)
             .name("char")
             .build(),
         DwarfInfoBuilder::new()
-            .offset(Offset::new(90))
+            .offset(Offset::new(93))
             .tag(DwarfTag::DW_TAG_base_type)
             .byte_size(4)
             .name("int")
             .build(),
         DwarfInfoBuilder::new()
-            .offset(Offset::new(97))
+            .offset(Offset::new(100))
             .tag(DwarfTag::DW_TAG_variable)
             .name("book")
             .type_offset(Offset::new(45))
             .location(Location::new(16428))
             .build(),
         DwarfInfoBuilder::new()
-            .offset(Offset::new(119))
+            .offset(Offset::new(122))
             .tag(DwarfTag::DW_TAG_unimplemented)
             .name("main")
-            .type_offset(Offset::new(90))
+            .type_offset(Offset::new(93))
             .build(),
     ];
 
@@ -594,16 +597,16 @@ fn extract_union() {
             vec![
                 UnionTypeMemberEntry {
                     name: String::from("name"),
-                    type_ref: TypeEntryId::new(Offset::new(83)),
+                    type_ref: TypeEntryId::new(Offset::new(86)),
                 },
                 UnionTypeMemberEntry {
                     name: String::from("price"),
-                    type_ref: TypeEntryId::new(Offset::new(90)),
+                    type_ref: TypeEntryId::new(Offset::new(93)),
                 },
             ],
         ),
-        TypeEntry::new_base_type_entry(TypeEntryId::new(Offset::new(83)), String::from("char"), 1),
-        TypeEntry::new_base_type_entry(TypeEntryId::new(Offset::new(90)), String::from("int"), 4),
+        TypeEntry::new_base_type_entry(TypeEntryId::new(Offset::new(86)), String::from("char"), 1),
+        TypeEntry::new_base_type_entry(TypeEntryId::new(Offset::new(93)), String::from("int"), 4),
     ];
 
     extract_test(infos, expected_variables, expected_types, Vec::new());

--- a/tests/library/dwarf_test.rs
+++ b/tests/library/dwarf_test.rs
@@ -362,40 +362,43 @@ fn dwarf_info_union() {
                     .offset(Offset::new(58))
                     .tag(DwarfTag::DW_TAG_unimplemented)
                     .name("name")
-                    .type_offset(Offset::new(83))
+                    .type_offset(Offset::new(86))
                     .build(),
                 DwarfInfoBuilder::new()
                     .offset(Offset::new(70))
                     .tag(DwarfTag::DW_TAG_unimplemented)
                     .name("price")
-                    .type_offset(Offset::new(90))
+                    .type_offset(Offset::new(93))
+                    .byte_size(4)
+                    .bit_size(8)
+                    .bit_offset(24)
                     .build(),
             ])
             .build(),
         DwarfInfoBuilder::new()
-            .offset(Offset::new(83))
+            .offset(Offset::new(86))
             .tag(DwarfTag::DW_TAG_base_type)
             .byte_size(1)
             .name("char")
             .build(),
         DwarfInfoBuilder::new()
-            .offset(Offset::new(90))
+            .offset(Offset::new(93))
             .tag(DwarfTag::DW_TAG_base_type)
             .byte_size(4)
             .name("int")
             .build(),
         DwarfInfoBuilder::new()
-            .offset(Offset::new(97))
+            .offset(Offset::new(100))
             .tag(DwarfTag::DW_TAG_variable)
             .name("book")
             .type_offset(Offset::new(45))
             .location(Location::new(16428))
             .build(),
         DwarfInfoBuilder::new()
-            .offset(Offset::new(119))
+            .offset(Offset::new(122))
             .tag(DwarfTag::DW_TAG_unimplemented)
             .name("main")
-            .type_offset(Offset::new(90))
+            .type_offset(Offset::new(93))
             .build(),
     ];
 


### PR DESCRIPTION
## Why
#23 

## What
- Create MemberEntry and commonize StrcutureMemberEntry and UnionMemberEntry
  - It enables us to add features to StructureMember and UnionMember together
- Remove redundant code from Factory
- Support union bit field