### PR TITLE
Stdout format for const struct and array

### DIFF
--- a/examples/const-array.c
+++ b/examples/const-array.c
@@ -1,0 +1,5 @@
+const int array[2];
+
+int main() {
+  return 0;
+}

--- a/src/domain/global_variable_view.rs
+++ b/src/domain/global_variable_view.rs
@@ -13,10 +13,6 @@ pub struct GlobalVariableView {
 }
 
 impl GlobalVariableView {
-    pub fn set_type_view(&mut self, type_view: TypeView) {
-        self.map_type_view(|_| type_view);
-    }
-
     pub fn map_type_view(&mut self, f: impl FnOnce(TypeView) -> TypeView) {
         self.type_view = f(self.type_view.clone())
     }


### PR DESCRIPTION
## Why
Applying the following const array:
```
const int array[2];
```
then, the output is like below:
```
address    size (bit)   variable_name        type
0x00004030 0x008        array                const const int[1]
0x00004030 0x004        0                    const int
0x00004034 0x004        1                    const int
```
Expected like below
```
address    size (bit)   variable_name        type
0x00004030 0x008        array                const const int[1]
0x00004030 0x004        array[0]             const int
0x00004034 0x004        array[1]             const int
```

## What
- Modify parent logic in stdout
