### PR TITLE
Support signed value in enumerator

### DIFF
--- a/examples/enum.c
+++ b/examples/enum.c
@@ -1,6 +1,7 @@
 enum AB {
   A,
-  B,
+  B = -1,
+  C = 0x20026,
 } ab;
 
 int main() {

--- a/src/domain/global_variable_view.rs
+++ b/src/domain/global_variable_view.rs
@@ -58,7 +58,7 @@ pub enum TypeView {
 #[derive(Debug, Clone, PartialEq)]
 pub struct Enumerator {
     pub name: String,
-    pub value: usize,
+    pub value: isize,
 }
 
 impl From<&EnumeratorEntry> for Enumerator {

--- a/src/domain/type_entry.rs
+++ b/src/domain/type_entry.rs
@@ -73,7 +73,7 @@ pub enum TypeEntryKind {
 #[derive(Debug, Clone, PartialEq)]
 pub struct EnumeratorEntry {
     pub name: String,
-    pub value: usize,
+    pub value: isize,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/library/dwarf.rs
+++ b/src/library/dwarf.rs
@@ -87,7 +87,7 @@ pub struct DwarfInfo {
     bit_offset: Option<usize>,
     location: Option<Location>,
     upper_bound: Option<usize>,
-    const_value: Option<usize>,
+    const_value: Option<isize>,
     data_member_location: Option<usize>,
     declaration: Option<bool>,
     specification: Option<Offset>,
@@ -131,7 +131,7 @@ impl DwarfInfo {
         self.upper_bound
     }
 
-    pub fn const_value(&self) -> Option<usize> {
+    pub fn const_value(&self) -> Option<isize> {
         self.const_value
     }
 
@@ -383,14 +383,12 @@ impl DwarfInfoIntoIterator {
             'unit,
             gimli::read::EndianSlice<'abbrev, gimli::RunTimeEndian>,
         >,
-    ) -> Option<usize> {
-        if let Some(gimli::read::AttributeValue::Data1(const_value)) =
-            entry.attr_value(gimli::DW_AT_const_value).unwrap()
-        {
-            Some(const_value as usize)
-        } else {
-            None
-        }
+    ) -> Option<isize> {
+        entry
+            .attr_value(gimli::DW_AT_const_value)
+            .unwrap()
+            .and_then(|value| value.sdata_value())
+            .map(|const_value| const_value as isize)
     }
 
     fn get_data_member_location<'abbrev, 'unit>(
@@ -507,7 +505,7 @@ pub struct DwarfInfoBuilder<OffsetP, TagP> {
     bit_offset: Option<usize>,
     location: Option<Location>,
     upper_bound: Option<usize>,
-    const_value: Option<usize>,
+    const_value: Option<isize>,
     data_member_location: Option<usize>,
     declaration: Option<bool>,
     specification: Option<Offset>,
@@ -634,7 +632,7 @@ impl<OffsetP, TagP> DwarfInfoBuilder<OffsetP, TagP> {
         self
     }
 
-    pub fn const_value(mut self, const_value: usize) -> Self {
+    pub fn const_value(mut self, const_value: isize) -> Self {
         self.const_value = Some(const_value);
         self
     }

--- a/src/library/dwarf.rs
+++ b/src/library/dwarf.rs
@@ -370,13 +370,11 @@ impl DwarfInfoIntoIterator {
             gimli::read::EndianSlice<'abbrev, gimli::RunTimeEndian>,
         >,
     ) -> Option<usize> {
-        if let Some(gimli::read::AttributeValue::Data1(upper_bound)) =
-            entry.attr_value(gimli::DW_AT_upper_bound).unwrap()
-        {
-            Some(upper_bound as usize)
-        } else {
-            None
-        }
+        entry
+            .attr_value(gimli::DW_AT_upper_bound)
+            .unwrap()
+            .and_then(|value| value.udata_value())
+            .map(|byte_size| byte_size as usize)
     }
 
     fn get_const_value<'abbrev, 'unit>(

--- a/tests/domain/global_variable_view_factory_test.rs
+++ b/tests/domain/global_variable_view_factory_test.rs
@@ -206,7 +206,7 @@ fn from_global_variable_enum() {
         TypeEntry::new_enum_type_entry(
             TypeEntryId::new(Offset::new(45)),
             Some(String::from("AB")),
-            TypeEntryId::new(Offset::new(71)),
+            TypeEntryId::new(Offset::new(78)),
             vec![
                 EnumeratorEntry {
                     name: String::from("A"),
@@ -214,16 +214,15 @@ fn from_global_variable_enum() {
                 },
                 EnumeratorEntry {
                     name: String::from("B"),
-                    value: 1,
+                    value: -1,
+                },
+                EnumeratorEntry {
+                    name: String::from("C"),
+                    value: 131110,
                 },
             ],
         ),
-        TypeEntry::new_base_type_entry(
-            TypeEntryId::new(Offset::new(71)),
-            String::from("unsigned int"),
-            4,
-        ),
-        TypeEntry::new_base_type_entry(TypeEntryId::new(Offset::new(129)), String::from("int"), 4),
+        TypeEntry::new_base_type_entry(TypeEntryId::new(Offset::new(78)), String::from("int"), 4),
     ];
 
     let global_variable = GlobalVariable::new_variable(
@@ -238,7 +237,7 @@ fn from_global_variable_enum() {
         .size(4)
         .type_view(TypeView::new_enum_type_view(
             Some("AB"),
-            TypeView::new_base_type_view("unsigned int"),
+            TypeView::new_base_type_view("int"),
             vec![
                 Enumerator {
                     name: String::from("A"),
@@ -246,7 +245,11 @@ fn from_global_variable_enum() {
                 },
                 Enumerator {
                     name: String::from("B"),
-                    value: 1,
+                    value: -1,
+                },
+                Enumerator {
+                    name: String::from("C"),
+                    value: 131110,
                 },
             ],
         ))

--- a/tests/domain/global_variables_extractor_test.rs
+++ b/tests/domain/global_variables_extractor_test.rs
@@ -263,7 +263,7 @@ fn extract_enum() {
             .tag(DwarfTag::DW_TAG_enumeration_type)
             .name("AB")
             .byte_size(4)
-            .type_offset(Offset::new(71))
+            .type_offset(Offset::new(78))
             .children(vec![
                 DwarfInfoBuilder::new()
                     .offset(Offset::new(62))
@@ -275,34 +275,34 @@ fn extract_enum() {
                     .offset(Offset::new(66))
                     .tag(DwarfTag::DW_TAG_enumerator)
                     .name("B")
-                    .const_value(1)
+                    .const_value(-1)
+                    .build(),
+                DwarfInfoBuilder::new()
+                    .offset(Offset::new(70))
+                    .tag(DwarfTag::DW_TAG_enumerator)
+                    .name("C")
+                    .const_value(131110)
                     .build(),
             ])
             .build(),
         DwarfInfoBuilder::new()
-            .offset(Offset::new(71))
+            .offset(Offset::new(78))
             .tag(DwarfTag::DW_TAG_base_type)
             .byte_size(4)
-            .name("unsigned int")
+            .name("int")
             .build(),
         DwarfInfoBuilder::new()
-            .offset(Offset::new(78))
+            .offset(Offset::new(85))
             .tag(DwarfTag::DW_TAG_variable)
             .name("ab")
             .type_offset(Offset::new(45))
             .location(Location::new(16428))
             .build(),
         DwarfInfoBuilder::new()
-            .offset(Offset::new(99))
+            .offset(Offset::new(106))
             .tag(DwarfTag::DW_TAG_unimplemented)
             .name("main")
-            .type_offset(Offset::new(129))
-            .build(),
-        DwarfInfoBuilder::new()
-            .offset(Offset::new(129))
-            .tag(DwarfTag::DW_TAG_base_type)
-            .byte_size(4)
-            .name("int")
+            .type_offset(Offset::new(78))
             .build(),
     ];
 
@@ -315,7 +315,7 @@ fn extract_enum() {
         TypeEntry::new_enum_type_entry(
             TypeEntryId::new(Offset::new(45)),
             Some(String::from("AB")),
-            TypeEntryId::new(Offset::new(71)),
+            TypeEntryId::new(Offset::new(78)),
             vec![
                 EnumeratorEntry {
                     name: String::from("A"),
@@ -323,16 +323,15 @@ fn extract_enum() {
                 },
                 EnumeratorEntry {
                     name: String::from("B"),
-                    value: 1,
+                    value: -1,
+                },
+                EnumeratorEntry {
+                    name: String::from("C"),
+                    value: 131110,
                 },
             ],
         ),
-        TypeEntry::new_base_type_entry(
-            TypeEntryId::new(Offset::new(71)),
-            String::from("unsigned int"),
-            4,
-        ),
-        TypeEntry::new_base_type_entry(TypeEntryId::new(Offset::new(129)), String::from("int"), 4),
+        TypeEntry::new_base_type_entry(TypeEntryId::new(Offset::new(78)), String::from("int"), 4),
     ];
 
     extract_test(infos, expected_variables, expected_types, Vec::new());

--- a/tests/library/dwarf_test.rs
+++ b/tests/library/dwarf_test.rs
@@ -176,7 +176,7 @@ fn dwarf_info_enum() {
             .tag(DwarfTag::DW_TAG_enumeration_type)
             .name("AB")
             .byte_size(4)
-            .type_offset(Offset::new(71))
+            .type_offset(Offset::new(78))
             .children(vec![
                 DwarfInfoBuilder::new()
                     .offset(Offset::new(62))
@@ -188,34 +188,34 @@ fn dwarf_info_enum() {
                     .offset(Offset::new(66))
                     .tag(DwarfTag::DW_TAG_enumerator)
                     .name("B")
-                    .const_value(1)
+                    .const_value(-1)
+                    .build(),
+                DwarfInfoBuilder::new()
+                    .offset(Offset::new(70))
+                    .tag(DwarfTag::DW_TAG_enumerator)
+                    .name("C")
+                    .const_value(131110)
                     .build(),
             ])
             .build(),
         DwarfInfoBuilder::new()
-            .offset(Offset::new(71))
+            .offset(Offset::new(78))
             .tag(DwarfTag::DW_TAG_base_type)
             .byte_size(4)
-            .name("unsigned int")
+            .name("int")
             .build(),
         DwarfInfoBuilder::new()
-            .offset(Offset::new(78))
+            .offset(Offset::new(85))
             .tag(DwarfTag::DW_TAG_variable)
             .name("ab")
             .type_offset(Offset::new(45))
             .location(Location::new(16428))
             .build(),
         DwarfInfoBuilder::new()
-            .offset(Offset::new(99))
+            .offset(Offset::new(106))
             .tag(DwarfTag::DW_TAG_unimplemented)
             .name("main")
-            .type_offset(Offset::new(129))
-            .build(),
-        DwarfInfoBuilder::new()
-            .offset(Offset::new(129))
-            .tag(DwarfTag::DW_TAG_base_type)
-            .byte_size(4)
-            .name("int")
+            .type_offset(Offset::new(78))
             .build(),
     ];
 


### PR DESCRIPTION
## Why
Not yet supported signed value in enumerator.
```
enum {
  a = -1,
};
```

## What
- support signed value
- support unsigned value with 8byte.